### PR TITLE
Sha of Anger only has one spawn point

### DIFF
--- a/Data/Mists/module.lua
+++ b/Data/Mists/module.lua
@@ -71,7 +71,7 @@ function module:OnInitialize()
 		[58817] = {name="Spirit of Lao-Fe",locations={[390]={47406620},},},
 		[58949] = {name="Bai-Jin the Butcher",locations={[390]={16404780},},},
 		[59369] = {name="Doctor Theolen Krastinov",locations={[476]={34404660,36402460,36403380,36403960,39205200},},},
-		[60491] = {name="Sha of Anger",boss=true,locations={[379]={51208760,53606460,67607460,70606380},},mount=473,quest=32099,},
+		[60491] = {name="Sha of Anger",boss=true,locations={[379]={53606460},},mount=473,quest=32099,},
 		[62346] = {name="Galleon",boss=true,locations={[376]={71606440},},mount=515,quest=32098,},
 		[62880] = {name="Gochao the Ironfist",locations={[390]={27001340},},},
 		[62881] = {name="Gaohun the Soul-Severer",locations={[390]={21201700,52205900,53006440},},},


### PR DESCRIPTION
On the small Worldmap the handynotes icon gets overlapped by the Blizzard one. Should the coords be changed to something else? 
![](https://i.imgur.com/uSTudi4.png)

