### PR TITLE
Shift+click HP rounding to whole number

### DIFF
--- a/targets/popup.lua
+++ b/targets/popup.lua
@@ -417,7 +417,7 @@ PopupClass.scripts = {
 			end
 			local text = ("%s %s|cffffff00|Hworldmap:%d:%d:%d|h[%s]|h|r"):format(
 				core:NameForMob(data.id, unit),
-				(unit and ('(' .. UnitHealth(unit) / UnitHealthMax(unit) * 100 .. '%) ') or ''),
+				(unit and ('(' .. math.ceil(UnitHealth(unit) / UnitHealthMax(unit) * 100) .. '%) ') or ''),
 				self.data.zone,
 				self.data.x * 10000,
 				self.data.y * 10000,


### PR DESCRIPTION
When linking mobs with less than 100% hp it would add like 20 decimals. just wrap the math in a rounding function to make it a whole number.