### PR TITLE
Announce player controlled mobs if are manually added

### DIFF
--- a/scan/targets.lua
+++ b/scan/targets.lua
@@ -86,9 +86,9 @@ local rare_nonflags = {
 function module:ProcessUnit(unit, source)
 	if not UnitExists(unit) then return end
 	if not UnitIsVisible(unit) then return end
-	if UnitPlayerControlled(unit) then return end -- helps filter out player-pets
 	local id = core:UnitID(unit)
 	if not id then return end
+	if UnitPlayerControlled(unit) and not globaldb.always[id] then return end -- helps filter out player-pets
 	local unittype = UnitClassification(unit)
 	local is_rare = (id and rare_nonflags[id]) or (unittype == 'rare' or unittype == 'rareelite')
 	local should_process = false


### PR DESCRIPTION
Force the announcement of manually added mobs even if they are controlled by the players, this  specially useful for achievements like [[Have... Have We Met?]](https://www.wowhead.com/achievement=5865/have-have-we-met) which requires to /wave some npcs that follow others players