### PR TITLE
Fix macro for classic when "Announce" is enabled

### DIFF
--- a/scan/macro.lua
+++ b/scan/macro.lua
@@ -64,7 +64,7 @@ function module:Update()
 		return
 	end
 	if not self.db.profile.enabled then
-		self:GetMacroButton(1):SetAttribute("macrotext", "/print \"Scanning macro disabled\"")
+		self:GetMacroButton(1):SetAttribute("macrotext", "/script print(\"Scanning macro disabled\")")
 		return
 	end
 	Debug("Updating Macro")
@@ -86,9 +86,9 @@ function module:Update()
 		end
 	end
 	if count == 0 then
-		table.insert(macro, "/print \"No mobs known to scan for\"")
+		table.insert(macro, "/script print(\"No mobs known to scan for\")")
 	elseif self.db.profile.verbose then
-		table.insert(macro, 1, ("/print \"Scanning for %d nearby mobs...\""):format(count))
+		table.insert(macro, 1, ("/script print(\"Scanning for %d nearby mobs...\")"):format(count))
 	end
 	local len = 0
 	local n = 1


### PR DESCRIPTION
WoW version: 3.4.0.46248 (Wrath of the Lich King)
Addon version: v2022.21

I noticed that the macro created by the addon didn't target rares. As I digged deeper and debugged, I noticed that the macro adds a `/print "Scanning for 4 nearby mobs..."` line at the beginning, when the option "Announce" in the macro settings was enabled.

But executing this line manually does not work. And this results into all following lines within the generated macro (`/targetexact ...`) to be also not executed.

Changing the outputs into `/script print("Scanning for 4 nearby mobs...")` does work. 

Please check if this is also the case for retail, I was not able to verify it there, only wotlk verified :)